### PR TITLE
Enable registerDefaults method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ var UserDefaults = require('react-native-userdefaults-ios');
 
 #### Writing to `standardUserDefaults`
 ```javascript
+// Register defaults
+UserDefaults.registerDefaults({'UserAgent': 'My-Custom-Agent'})
+    .then(result => {
+        console.log(result);
+    });
+
 //Set an Array...
 var arr = ['1', '2', '3'];
 UserDefaults.setArrayForKey(arr, 'keyForMyArray')

--- a/RNUserDefaultsIOS.js
+++ b/RNUserDefaultsIOS.js
@@ -4,6 +4,8 @@ var { NativeModules } = require('react-native');
 var Promise = require('bluebird'); // jshint ignore:line
 var UserDefaults = NativeModules.RNUserDefaultsIOS;
 
+var _registerDefaults = Promise.promisify(UserDefaults.registerDefaults);
+
 var _setObjectForKey = Promise.promisify(UserDefaults.setObjectForKey);
 var _setBoolForKey = Promise.promisify(UserDefaults.setBoolForKey);
 
@@ -15,6 +17,9 @@ var _boolForKey = Promise.promisify(UserDefaults.boolForKey);
 var _removeItemForKey = Promise.promisify(UserDefaults.removeObjectForKey);
 
 var UserDefaults = {
+    registerDefaults(defs) {
+        return _registerDefaults(defs);
+    },
     setArrayForKey(array, key) {
         return _setObjectForKey(array, key);
     },

--- a/RNUserDefaultsIOS/RNUserDefaultsIOS.m
+++ b/RNUserDefaultsIOS/RNUserDefaultsIOS.m
@@ -13,6 +13,13 @@
 
 RCT_EXPORT_MODULE()
 
+RCT_EXPORT_METHOD(registerDefaults:(NSDictionary*)dict callback:(RCTResponseSenderBlock)callback) {
+    
+    [UserDefaultsManager registerDefaults:dict];
+    
+    callback(@[[NSNull null], @"success"]);
+}
+
 RCT_EXPORT_METHOD(setObjectForKey:(id)object key:(NSString *)key callback:(RCTResponseSenderBlock)callback) {
     
     [UserDefaultsManager setObject:object forKey:key];

--- a/RNUserDefaultsIOS/UserDefaultsManager.h
+++ b/RNUserDefaultsIOS/UserDefaultsManager.h
@@ -10,6 +10,8 @@
 
 @interface UserDefaultsManager : NSObject
 
++ (void)registerDefaults:(NSDictionary*)dict;
+
 + (void)setObject:(id)object forKey:(NSString *)key;
 
 + (void)setBool:(bool)value forKey:(NSString *)key;

--- a/RNUserDefaultsIOS/UserDefaultsManager.m
+++ b/RNUserDefaultsIOS/UserDefaultsManager.m
@@ -10,6 +10,10 @@
 
 @implementation UserDefaultsManager
 
++ (void)registerDefaults:(NSDictionary*)dict {
+    [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
+}
+
 + (void)setObject:(id)object forKey:(NSString *)key {
     
     [[NSUserDefaults standardUserDefaults] setObject:object forKey:key];

--- a/RNUserDefaultsIOSTests/UserDefaultsManagerSpec.m
+++ b/RNUserDefaultsIOSTests/UserDefaultsManagerSpec.m
@@ -6,6 +6,11 @@
 
 #import "UserDefaultsManager.h"
 
+#ifndef RCTRegisterModule
+void RCTRegisterModule() {
+}
+#endif
+
 @interface UserDefaultsManager (Test)
 @end
 
@@ -22,7 +27,16 @@ describe(@"UserDefaultsManager", ^{
     });
     
     describe(@"writing", ^{
-        
+        describe(@"#registerDefaults:", ^{
+            it(@"", ^{
+
+                NSDictionary *dictionary = [[NSDictionary alloc] initWithObjectsAndKeys:@"My-Custom-User-Agent", @"UserAgent", nil];
+                
+                [UserDefaultsManager registerDefaults:dictionary];
+
+                expect([userDefaults stringForKey:@"UserAgent"]).to.equal(@"My-Custom-User-Agent");
+            });
+        });
         describe(@"#setObject:forKey:", ^{
             
             it(@"sets a string for given key", ^{


### PR DESCRIPTION
This patch adds a new method `UserDefaults.registerDefaults()`, as a frontend for `[NSUserDefaults standardUserDefaults] registerDefaults` method.

We're looking to use this for configuring user agent at app startup time.

The relevant sections in tests and doc are updated as well.